### PR TITLE
Add yt-dlp download button feature with settings UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1840,6 +1841,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1890,6 +1892,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -2116,6 +2119,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2233,6 +2237,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2487,6 +2492,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3682,6 +3688,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3691,6 +3698,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3979,6 +3987,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4031,6 +4040,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4086,6 +4096,7 @@
       "integrity": "sha512-qTl3VF7BvOupTR85Zc561sPEgxyUSNSvTQ9fit7DEMP7yPgvvIGm5Zfa1dOM+kOwWGNviK9uFM9ra77+OjK7lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4179,6 +4190,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4238,6 +4250,7 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { useSettings } from '../hooks/useSettings';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const { settings, updateSetting } = useSettings();
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-neutral-800 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-neutral-700">
+          <h2 className="text-2xl font-semibold text-white">Settings</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white transition-colors p-2 rounded-lg hover:bg-neutral-700"
+            aria-label="Close settings"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Settings Content */}
+        <div className="p-6 space-y-6">
+          {/* Download Features Section */}
+          <section>
+            <h3 className="text-lg font-semibold text-white mb-4">Download Features</h3>
+            <div className="space-y-4">
+              {/* Enable Download Buttons Toggle */}
+              <div className="flex items-start justify-between p-4 bg-neutral-750 rounded-xl">
+                <div className="flex-1">
+                  <label
+                    htmlFor="enable-download-buttons"
+                    className="text-white font-medium cursor-pointer"
+                  >
+                    Enable Download Buttons
+                  </label>
+                  <p className="text-sm text-gray-400 mt-1">
+                    Show a download button on each video card that copies a yt-dlp command to your
+                    clipboard. The command includes metadata, thumbnail, and subtitle downloads.
+                  </p>
+                </div>
+                <div className="ml-4">
+                  <button
+                    id="enable-download-buttons"
+                    role="switch"
+                    aria-checked={settings.enableDownloadButtons}
+                    onClick={() =>
+                      updateSetting('enableDownloadButtons', !settings.enableDownloadButtons)
+                    }
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-neutral-800 ${
+                      settings.enableDownloadButtons ? 'bg-blue-600' : 'bg-neutral-600'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        settings.enableDownloadButtons ? 'translate-x-6' : 'translate-x-1'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Account Settings Section (Placeholder) */}
+          <section>
+            <h3 className="text-lg font-semibold text-white mb-4">Account Settings</h3>
+            <div className="space-y-3 opacity-50">
+              <div className="flex items-center justify-between p-4 bg-neutral-750 rounded-xl cursor-not-allowed">
+                <div className="flex items-center gap-3">
+                  <svg
+                    className="w-5 h-5 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                    />
+                  </svg>
+                  <div>
+                    <div className="text-white font-medium">Export Data</div>
+                    <div className="text-xs text-gray-400">Download your watched history and preferences</div>
+                  </div>
+                </div>
+                <span className="text-xs text-gray-500 bg-neutral-700 px-2 py-1 rounded">
+                  Coming Soon
+                </span>
+              </div>
+
+              <div className="flex items-center justify-between p-4 bg-neutral-750 rounded-xl cursor-not-allowed">
+                <div className="flex items-center gap-3">
+                  <svg
+                    className="w-5 h-5 text-red-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  <div>
+                    <div className="text-white font-medium">Delete Account</div>
+                    <div className="text-xs text-gray-400">
+                      Permanently delete your account and all data
+                    </div>
+                  </div>
+                </div>
+                <span className="text-xs text-gray-500 bg-neutral-700 px-2 py-1 rounded">
+                  Coming Soon
+                </span>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-neutral-700 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { FeedItem } from '../api/client';
+import { useSettings } from '../hooks/useSettings';
 
 interface VideoCardProps {
   video: FeedItem;
@@ -14,7 +15,9 @@ export default function VideoCard({
   onMarkWatched,
   onUnmarkWatched,
 }: VideoCardProps) {
+  const { settings } = useSettings();
   const [isUpdating, setIsUpdating] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
   const publishedDate = new Date(video.published);
   const formattedDate = publishedDate.toLocaleString('en-US', {
     year: 'numeric',
@@ -51,6 +54,36 @@ export default function VideoCard({
         await onMarkWatched(video.video_id, video.channel_id);
       } catch (error) {
         console.error('Failed to mark as watched:', error);
+      }
+    }
+  };
+
+  const handleCopyDownloadCommand = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const ytDlpCommand = `yt-dlp --add-metadata --embed-thumbnail --write-auto-sub --embed-subs ${video.link}`;
+
+    try {
+      await navigator.clipboard.writeText(ytDlpCommand);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+      // Fallback: try to use the older execCommand method
+      try {
+        const textArea = document.createElement('textarea');
+        textArea.value = ytDlpCommand;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 2000);
+      } catch (fallbackError) {
+        console.error('Fallback copy also failed:', fallbackError);
       }
     }
   };
@@ -180,6 +213,41 @@ export default function VideoCard({
                   )}
                 </button>
               )}
+
+              {/* Download button */}
+              {settings.enableDownloadButtons && (
+                <button
+                  onClick={handleCopyDownloadCommand}
+                  className="inline-flex items-center text-sm px-3 py-1 rounded-lg transition-colors bg-neutral-700 hover:bg-neutral-600 text-gray-300"
+                  title="Copy yt-dlp command"
+                >
+                  {isCopied ? (
+                    <>
+                      <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                        />
+                      </svg>
+                      Download
+                    </>
+                  )}
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -294,6 +362,35 @@ export default function VideoCard({
                     strokeLinejoin="round"
                     strokeWidth={2}
                     d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                  />
+                </svg>
+              )}
+            </button>
+          )}
+
+          {/* Download button */}
+          {settings.enableDownloadButtons && (
+            <button
+              onClick={handleCopyDownloadCommand}
+              className="inline-flex items-center justify-center text-xs p-1.5 rounded transition-colors bg-neutral-700 hover:bg-neutral-600 text-gray-300"
+              title="Copy yt-dlp command"
+            >
+              {isCopied ? (
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              ) : (
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
                   />
                 </svg>
               )}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface AppSettings {
+  enableDownloadButtons: boolean;
+}
+
+const SETTINGS_KEY = 'yt-feed-settings';
+
+const DEFAULT_SETTINGS: AppSettings = {
+  enableDownloadButtons: false,
+};
+
+/**
+ * Load settings from localStorage
+ */
+function loadSettings(): AppSettings {
+  try {
+    const stored = localStorage.getItem(SETTINGS_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return { ...DEFAULT_SETTINGS, ...parsed };
+    }
+  } catch (error) {
+    console.error('Failed to load settings from localStorage:', error);
+  }
+  return DEFAULT_SETTINGS;
+}
+
+/**
+ * Save settings to localStorage
+ */
+function saveSettings(settings: AppSettings): void {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch (error) {
+    console.error('Failed to save settings to localStorage:', error);
+  }
+}
+
+/**
+ * React hook for managing app settings with localStorage persistence
+ */
+export function useSettings() {
+  const [settings, setSettings] = useState<AppSettings>(loadSettings);
+
+  useEffect(() => {
+    saveSettings(settings);
+  }, [settings]);
+
+  const updateSetting = useCallback(<K extends keyof AppSettings>(
+    key: K,
+    value: AppSettings[K]
+  ) => {
+    setSettings(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS);
+  }, []);
+
+  return {
+    settings,
+    updateSetting,
+    resetSettings,
+  };
+}

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -6,6 +6,7 @@ import ChannelSidebar from '../components/ChannelSidebar';
 import Pagination from '../components/Pagination';
 import ViewToggle from '../components/ViewToggle';
 import WatchedFilter from '../components/WatchedFilter';
+import SettingsModal from '../components/SettingsModal';
 
 export default function Feed() {
   const navigate = useNavigate();
@@ -18,6 +19,7 @@ export default function Feed() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hideWatched, setHideWatched] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   // Pagination state
   const [cursors, setCursors] = useState<(string | null)[]>([null]);
@@ -267,6 +269,26 @@ export default function Feed() {
                     {user.display_name}
                   </span>
                   <button
+                    onClick={() => setIsSettingsOpen(true)}
+                    className="p-2 text-gray-400 hover:text-white hover:bg-neutral-700 rounded-lg transition-colors"
+                    title="Settings"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                      />
+                    </svg>
+                  </button>
+                  <button
                     onClick={handleLogout}
                     className="px-4 py-2 text-sm bg-neutral-700 hover:bg-neutral-600 rounded-lg transition-colors"
                   >
@@ -359,6 +381,9 @@ export default function Feed() {
           </main>
         </div>
       </div>
+
+      {/* Settings Modal */}
+      <SettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
Implemented a feature-gated download button on video cards that copies a yt-dlp command to the clipboard for easy offline video downloads.

Features:
- Settings modal with toggle to enable/disable download buttons (default: disabled)
- Settings persisted in localStorage (frontend-only, no backend changes)
- Download button on each video card (both grid and list views)
- yt-dlp command includes: --add-metadata --embed-thumbnail --write-auto-sub --embed-subs
- Visual feedback: Button shows "Copied!" for 2 seconds after copying
- Fallback clipboard method for older browsers
- Settings icon in header navigation
- Placeholder section for future account settings (export data, delete account)

Files created:
- frontend/src/hooks/useSettings.ts - localStorage-based settings management
- frontend/src/components/SettingsModal.tsx - Settings UI with toggles

Files modified:
- frontend/src/components/VideoCard.tsx - Added download button with clipboard functionality
- frontend/src/pages/Feed.tsx - Added settings button and modal integration

All TypeScript compilation and ESLint checks passed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
- 

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README/CHANGELOG)
- [ ] Affected code has owners’ review
- [ ] Code is licensed as required in the CONTRIBUTING.md file

## Security
- Notes on threat model / permissions / secrets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings modal accessible from the main interface with downloadable features toggle
  * Introduced download button on video cards that copies download commands to clipboard
  * Download button displays "Copied!" confirmation when the command is successfully copied
  * Settings are persisted locally and remembered across sessions
  * Added Account Settings section (coming soon) for future expansion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->